### PR TITLE
feat: [#3] Publishing into exchanges

### DIFF
--- a/examples/bunny/publisher_and_consumer_with_ack.rb
+++ b/examples/bunny/publisher_and_consumer_with_ack.rb
@@ -3,7 +3,7 @@ require "benchmark"
 require "json"
 require "securerandom"
 
-puts "A channel for publishing, another for consuming, with ACK for publishing and consuming"
+puts "Publisher with ack confirmation, subscriber with ack"
 
 EVENT_NAME = "orders.create"
 EXCHANGE_OPTS = {type: :fanout, durable: true}
@@ -14,46 +14,8 @@ session = Bunny.new({
   username: "guest",
   password: "guest",
   vhost: "/",
-  logger: Logger.new($stdout)
+  logger: Logger.new($stdout, level: :INFO)
 }).start
-
-Subscriber = Class.new do
-  attr_reader :channel, :queue
-
-  def initialize(session:, queue_name:)
-    @session = session
-    @queue_name = queue_name
-    create_channel
-    declare_exchange
-    declare_queue
-    subscribe
-  end
-
-  private
-
-  attr_reader :session, :exchange, :consumer
-
-  def create_channel
-    @channel = session.create_channel
-  end
-
-  def declare_exchange
-    @exchange = channel.exchange(EVENT_NAME, EXCHANGE_OPTS)
-  end
-
-  def declare_queue
-    @queue = channel.queue(EVENT_NAME + "." + @queue_name, durable: true).bind(exchange)
-  end
-
-  def subscribe
-    @consumer = queue.subscribe(manual_ack: true, &method(:on_delivery))
-  end
-
-  def on_delivery(delivery_info, message_properties, content)
-    pp "delivery_info: #{delivery_info}, message_properties: #{message_properties}, content: #{content}"
-    channel.ack(delivery_info.delivery_tag, false)
-  end
-end
 
 Publisher = Class.new do
   attr_reader :channel
@@ -65,7 +27,8 @@ Publisher = Class.new do
   end
 
   def call(data)
-    pp "Next publish seq_no: #{channel.next_publish_seq_no}"
+    payload = {tags: ["publisher"], message: "Publishing a message", data: data, next_publish_seq_no: channel.next_publish_seq_no}
+    pp payload.to_json
     exchange.publish(JSON.generate(data), {message_id: SecureRandom.uuid, persistent: true})
   end
 
@@ -83,19 +46,72 @@ Publisher = Class.new do
   end
 
   def on_ack(delivery_tag, unused_arg, nack)
-    pp "published ACK received for delivery_tag: #{delivery_tag}, unused_arg: #{unused_arg}, nack: #{nack}"
+    payload = {tags: ["publisher"], message: "ack received", delivery_tag: delivery_tag, unused_arg: unused_arg, nack: nack}
+    pp payload.to_json
   end
 end
 
-subscriber = Subscriber.new(session: session, queue_name: "queue")
-result = Publisher.new(session).call({msg: SecureRandom.random_number})
-pp "Message published, result: #{result}"
+Subscriber = Class.new do
+  attr_reader :channel, :queue, :consumer
 
-loop do
-  puts "-------------------------------------"
-  puts "Checking queue messages..."
-  break if subscriber.queue.message_count == 0
-  puts "Sleeping since the queue still has messages"
-  sleep(1)
-  puts "-------------------------------------"
+  def initialize(session:, queue_name:)
+    @session = session
+    @queue_name = queue_name
+    @channel = create_channel
+    @exchange = declare_exchange
+    @queue = declare_queue
+    @consumer = subscribe
+  end
+
+  private
+
+  attr_reader :session, :exchange
+
+  def create_channel
+    channel = session.create_channel
+    # 1 message to pre-fetch per consumer
+    channel.basic_qos(1, false)
+    channel
+  end
+
+  def declare_exchange
+    channel.exchange(EVENT_NAME, EXCHANGE_OPTS)
+  end
+
+  def declare_queue
+    queue = channel.queue(EVENT_NAME + "." + @queue_name, durable: true).bind(exchange)
+    payload = {tags: ["subscriber"], message: "queue status", queue: queue.name, message_count: queue.message_count}
+    pp payload.to_json
+    queue
+  end
+
+  def subscribe
+    queue.subscribe(manual_ack: true, &method(:on_delivery))
+  end
+
+  def on_delivery(delivery_info, message_properties, content)
+    payload = {tags: ["subscriber"], message: "message received", delivery_info: delivery_info, message_properties: message_properties, content: content}
+    pp payload.to_json
+    sleep 5
+    # channel.ack(delivery_info.delivery_tag, false)
+    raise StandardError.new("An exception ocurred")
+  rescue => e
+    payload = {tags: ["subscriber"], message: "exception occurred", exception: {class: e.class, message: e.message}}
+    pp payload.to_json
+    channel.basic_reject(delivery_info.delivery_tag, true)
+  end
+end
+
+publisher = Publisher.new(session).call({msg: SecureRandom.random_number})
+subscriber = Subscriber.new(session: session, queue_name: "queue")
+
+begin
+  sleep
+rescue SignalException => e
+  payload = {tags: ["planifier"], message: "signal received", signo: e.signo}
+  puts payload.to_json
+  subscriber.consumer.cancel
+  subscriber.channel.close
+  publisher.channel.close
+  session.close
 end

--- a/lib/harmoniser.rb
+++ b/lib/harmoniser.rb
@@ -1,8 +1,19 @@
-# frozen_string_literal: true
-
-require_relative "harmoniser/version"
+require "harmoniser/version"
+require "harmoniser/configurable"
+require "harmoniser/publisher"
 
 module Harmoniser
-  class Error < StandardError; end
-  # Your code goes here...
+  extend Configurable
+  # at_exit do
+  #   puts "*" * 80
+  #   puts "at_exit fired"
+  #   puts "*" * 80
+  # end
+
+  # Signal.trap "SIGINT" do
+  #   puts "*" * 80
+  #   puts "Received SIGINT"
+  #   puts "*" * 80
+  #   exit(0)
+  # end
 end

--- a/lib/harmoniser/channelable.rb
+++ b/lib/harmoniser/channelable.rb
@@ -1,0 +1,26 @@
+module Harmoniser
+  module Channelable
+    MUTEX = Mutex.new
+    private_constant :MUTEX
+
+    module ClassMethods
+      def harmoniser_channel
+        MUTEX.synchronize do
+          @harmoniser_channel ||= create_channel
+        end
+      end
+
+      def create_channel
+        session = Harmoniser.bunny
+        session.start
+        session.create_channel
+      end
+    end
+
+    class << self
+      def included(base)
+        base.extend(ClassMethods)
+      end
+    end
+  end
+end

--- a/lib/harmoniser/configurable.rb
+++ b/lib/harmoniser/configurable.rb
@@ -1,0 +1,21 @@
+require "forwardable"
+require "harmoniser/configuration"
+
+module Harmoniser
+  module Configurable
+    extend Forwardable
+
+    def configure
+      @configuration ||= Configuration.new
+      yield(@configuration)
+    end
+
+    def configuration
+      raise NoMethodError.new("Please, configure first") unless @configuration
+
+      @configuration
+    end
+
+    def_delegators :configuration, :logger, :bunny
+  end
+end

--- a/lib/harmoniser/configuration.rb
+++ b/lib/harmoniser/configuration.rb
@@ -1,0 +1,22 @@
+require "bunny"
+require "logger"
+
+module Harmoniser
+  class Configuration
+    attr_reader :bunny, :logger
+
+    def initialize
+      @logger = Logger.new($stdout)
+    end
+
+    def bunny=(value)
+      if value.is_a?(Bunny::Session)
+        @bunny = value
+      elsif value.is_a?(Hash)
+        @bunny = Bunny.new({logger: @logger}.merge(value))
+      else
+        raise ArgumentError.new("Hash or Bunny argument is expected")
+      end
+    end
+  end
+end

--- a/lib/harmoniser/publisher.rb
+++ b/lib/harmoniser/publisher.rb
@@ -1,0 +1,38 @@
+require "harmoniser/channelable"
+
+module Harmoniser
+  module Publisher
+    include Channelable
+    MUTEX = Mutex.new
+    private_constant :MUTEX
+
+    module ClassMethods
+      def harmoniser_publisher(name:, channel: nil, type: :fanout, opts: {})
+        a_channel = channel || Publisher.harmoniser_channel
+        MUTEX.synchronize do
+          @harmoniser_exchange ||= Bunny::Exchange.new(
+            a_channel,
+            type,
+            name,
+            opts
+          )
+        end
+        yield(@harmoniser_exchange) if block_given?
+        @harmoniser_exchange
+      end
+
+      def publish(payload, opts = {})
+        MUTEX.synchronize do
+          @harmoniser_exchange
+            .publish(payload, opts)
+        end
+      end
+    end
+
+    class << self
+      def included(base)
+        base.extend(ClassMethods)
+      end
+    end
+  end
+end

--- a/spec/harmoniser/channelable_spec.rb
+++ b/spec/harmoniser/channelable_spec.rb
@@ -1,0 +1,35 @@
+require "harmoniser/channelable"
+require "shared_context/configurable"
+
+RSpec.describe Harmoniser::Channelable do
+  include_context "configurable"
+
+  let(:klass) do
+    Class.new do
+      include Harmoniser::Channelable
+    end
+  end
+
+  it "MUTEX constant is private" do
+    expect do
+      klass::MUTEX
+    end.to raise_error(NameError, /private constant/)
+  end
+
+  describe ".harmoniser_channel" do
+    it "return a Bunny::Channel" do
+      result = klass.harmoniser_channel
+
+      expect(result).to be_an_instance_of(Bunny::Channel)
+    end
+
+    it "channel creation is thread-safe" do
+      channel_creation = lambda { klass.harmoniser_channel }
+
+      result1 = Thread.new(&channel_creation)
+      result2 = Thread.new(&channel_creation)
+
+      expect(result1.value.object_id).to eq(result2.value.object_id)
+    end
+  end
+end

--- a/spec/harmoniser/configurable_spec.rb
+++ b/spec/harmoniser/configurable_spec.rb
@@ -1,0 +1,67 @@
+require "harmoniser/configurable"
+
+RSpec.describe Harmoniser::Configurable do
+  subject do
+    Class.new do
+      extend Harmoniser::Configurable
+    end
+  end
+
+  describe ".configure" do
+    it "yield a configuration object" do
+      expect do |b|
+        subject.configure(&b)
+      end.to yield_with_args(be_an_instance_of(Harmoniser::Configuration))
+    end
+
+    it "configuration object is memoized" do
+      configuration = nil
+      configuration2 = nil
+
+      subject.configure { |config| configuration = config }
+      subject.configure { |config| configuration2 = config }
+
+      expect(configuration.object_id).to eq(configuration2.object_id)
+    end
+  end
+
+  describe ".configuration" do
+    it "return configuration object" do
+      subject.configure {}
+
+      expect(subject.configuration).to be_an_instance_of(Harmoniser::Configuration)
+    end
+  end
+
+  describe ".logger" do
+    it "forward to configuration object" do
+      subject.configure {}
+
+      expect(subject.logger).to be_an_instance_of(Logger)
+    end
+
+    context "when configuration object is not set" do
+      it "raise NoMethodError" do
+        expect do
+          subject.logger
+        end.to raise_error(NoMethodError, /Please, configure first/)
+      end
+    end
+  end
+
+  describe ".bunny" do
+    it "forward to configuration object" do
+      subject.configure { |config| config.bunny = {} }
+
+      expect(subject.bunny).to be_an_instance_of(Bunny::Session)
+    end
+
+    context "when configuration object is not set" do
+      it "raise NoMethodError" do
+        expect do
+          subject.bunny
+        end.to raise_error(NoMethodError, /Please, configure first/)
+      end
+    end
+  end
+end

--- a/spec/harmoniser/configuration_spec.rb
+++ b/spec/harmoniser/configuration_spec.rb
@@ -1,0 +1,52 @@
+require "harmoniser/configuration"
+
+RSpec.describe Harmoniser::Configuration do
+  describe "#bunny=" do
+    subject { described_class.new }
+
+    context "when hash of options is passed" do
+      before do
+        allow(Bunny).to receive(:new)
+      end
+
+      it "forward them to Bunny" do
+        subject.bunny = {host: "a_host", port: "a_port", user: "wadus", pass: "S3cret_password", vhost: "/"}
+
+        expect(Bunny).to have_received(:new).with(
+          host: "a_host",
+          port: "a_port",
+          user: "wadus",
+          pass: "S3cret_password",
+          vhost: "/",
+          logger: subject.logger
+        )
+      end
+
+      context "but includes logger" do
+        it "respect logger option passed" do
+          logger = Logger.new(IO::NULL)
+
+          subject.bunny = {host: "a_host", port: "a_port", user: "wadus", pass: "S3cret_password", vhost: "/", logger: logger}
+
+          expect(Bunny).to have_received(:new).with(
+            include(logger: logger)
+          )
+        end
+      end
+    end
+
+    context "when Bunny instance is passed" do
+      it "set bunny instance variable" do
+        subject.bunny = Bunny.new({})
+
+        expect(subject.bunny).to be_an_instance_of(Bunny::Session)
+      end
+    end
+
+    it "raises ArgumentError" do
+      expect do
+        subject.bunny = nil
+      end.to raise_error(ArgumentError, "Hash or Bunny argument is expected")
+    end
+  end
+end

--- a/spec/harmoniser/publisher_spec.rb
+++ b/spec/harmoniser/publisher_spec.rb
@@ -1,0 +1,110 @@
+require "harmoniser/publisher"
+require "shared_context/configurable"
+
+RSpec.describe Harmoniser::Publisher do
+  include_context "configurable"
+
+  let(:klass) do
+    Class.new do
+      include Harmoniser::Publisher
+    end
+  end
+
+  it "MUTEX constant is private" do
+    expect do
+      klass::MUTEX
+    end.to raise_error(NameError, /private constant/)
+  end
+
+  describe ".harmoniser_publisher" do
+    it "return a Bunny::Exchange" do
+      result = klass.harmoniser_publisher(name: "an_exchange_name")
+
+      expect(result).to be_an_instance_of(Bunny::Exchange)
+    end
+
+    context "when block is given" do
+      it "yield a Bunny::Exchange for setting advance configuration" do
+        expect do |b|
+          klass.harmoniser_publisher(name: "an_exchange_name", &b)
+        end.to yield_with_args(be_an_instance_of(Bunny::Exchange))
+      end
+    end
+
+    it "exchange declaration is thread-safe" do
+      exchange_declaration = lambda { klass.harmoniser_publisher(name: "an_exchange_name") }
+
+      result1 = Thread.new(&exchange_declaration)
+      result2 = Thread.new(&exchange_declaration)
+
+      expect(result1.value.object_id).to eq(result2.value.object_id)
+    end
+
+    context "when two different name are declared for the same publisher" do
+      it "first declaration is chosen" do
+        result1 = klass.harmoniser_publisher(name: "an_exchange_name")
+        result2 = klass.harmoniser_publisher(name: "another_exchange_name")
+
+        expect(result1.name).to eq("an_exchange_name")
+        expect(result2.name).to eq("an_exchange_name")
+      end
+    end
+  end
+
+  describe ".publish" do
+    let!(:exchange) do
+      klass.harmoniser_publisher(name: "exchange") do |exchange|
+        queue = exchange.channel.queue("", auto_delete: true).bind(exchange)
+        @consumed = false
+        queue.subscribe do |delivery_info, properties, payload|
+          @consumed = true
+        end
+      end
+    end
+
+    it "publish a message" do
+      klass.publish("foo")
+
+      expect do
+        require "timeout"
+        Timeout.timeout(2) do
+          until @consumed; end
+        end
+      end.not_to raise_error
+    end
+
+    it "channel is shared across publications" do
+      result1 = klass.publish("foo").channel
+      result2 = klass.publish("bar").channel
+
+      expect(result1.object_id).to eq(result2.object_id)
+    end
+
+    it "publication is thread-safe" do
+      exchange_publication = lambda { klass.publish("foo") }
+      result1 = Thread.new(&exchange_publication)
+      result2 = Thread.new(&exchange_publication)
+
+      expect do
+        result1.value
+        result2.value
+      end.not_to raise_error(Bunny::Exception)
+    end
+
+    context "declare exchange with defaults" do
+      # TODO
+    end
+
+    context "serialisation" do
+      # TODO
+    end
+
+    context "handle errors" do
+      # TODO
+    end
+
+    context "handle OS signals" do
+      # TODO
+    end
+  end
+end

--- a/spec/harmoniser_spec.rb
+++ b/spec/harmoniser_spec.rb
@@ -1,7 +1,17 @@
-# frozen_string_literal: true
-
 RSpec.describe Harmoniser do
   it "has a version number" do
-    expect(Harmoniser::VERSION).not_to be nil
+    expect(described_class::VERSION).not_to be nil
+  end
+
+  describe ".configuration" do
+    it "respond_to configuration" do
+      expect(described_class).to respond_to(:configuration)
+    end
+  end
+
+  describe ".configure" do
+    it "respond_to configure" do
+      expect(described_class).to respond_to(:configure)
+    end
   end
 end

--- a/spec/shared_context/configurable.rb
+++ b/spec/shared_context/configurable.rb
@@ -1,0 +1,7 @@
+RSpec.shared_context "configurable" do
+  before(:each) do
+    Harmoniser.configure do |config|
+      config.bunny = {host: "rabbitmq"}
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces `harmoniser_publisher`. A class method to be
added to any class/module in order to publish messages into exchanges.

This publishes is able to:
- re-use a Session
- re-use a channel for declaring exchanges
- re-use a channel for publishing into exchanges
- handles thread-safety for declaring/publishing
- offer flexibility to customise the exchange declared