### PR TITLE
tech: #11 Control lifecycle of connection to Bunny

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Roadmap
 
+- Add other properties to DEFAULT_CONNECTION_OPTS like heartbeat, connection_timeout,
+  read_timeout, write_timeout, recovery_completed, recovery_attempt_started, connection_name
 - Explore if Exchange#on_return might be proxied through Harmoniser::Publisher
 - Evaluate if there is any benefit on using Channel#synchronize instead of a mutex for each publication
 - Explore if Channel#on_error or Channel#on_uncaught_exception should be proxied through Harmoniser::Publisher or Harmoniser::Subscriber

--- a/lib/harmoniser.rb
+++ b/lib/harmoniser.rb
@@ -5,16 +5,4 @@ require "harmoniser/subscriber"
 
 module Harmoniser
   extend Configurable
-  # at_exit do
-  #   puts "*" * 80
-  #   puts "at_exit fired"
-  #   puts "*" * 80
-  # end
-
-  # Signal.trap "SIGINT" do
-  #   puts "*" * 80
-  #   puts "Received SIGINT"
-  #   puts "*" * 80
-  #   exit(0)
-  # end
 end

--- a/lib/harmoniser/channelable.rb
+++ b/lib/harmoniser/channelable.rb
@@ -11,9 +11,8 @@ module Harmoniser
       end
 
       def create_channel
-        session = Harmoniser.bunny
-        session.start
-        session.create_channel
+        connection = Harmoniser.connection
+        connection.create_channel
       end
     end
 

--- a/lib/harmoniser/configurable.rb
+++ b/lib/harmoniser/configurable.rb
@@ -16,6 +16,6 @@ module Harmoniser
       @configuration
     end
 
-    def_delegators :configuration, :logger, :bunny
+    def_delegators :configuration, :logger, :connection
   end
 end

--- a/lib/harmoniser/connection.rb
+++ b/lib/harmoniser/connection.rb
@@ -1,0 +1,13 @@
+require "forwardable"
+require "bunny"
+
+module Harmoniser
+  class Connection
+    extend Forwardable
+    def_delegators :@bunny, :create_channel, :start
+
+    def initialize(opts)
+      @bunny = Bunny.new(opts)
+    end
+  end
+end

--- a/lib/harmoniser/connection_opts.rb
+++ b/lib/harmoniser/connection_opts.rb
@@ -1,0 +1,13 @@
+module Harmoniser
+  ConnectionOpts = Data.define(
+    :host,
+    :password,
+    :port,
+    :tls_silence_warnings,
+    :username,
+    :verify_peer,
+    :vhost
+  )
+
+  DEFAULT_CONNECTION_OPTS = ConnectionOpts.new(host: "127.0.0.1", password: "guest", port: 5672, tls_silence_warnings: true, username: "guest", verify_peer: false, vhost: "/")
+end

--- a/spec/harmoniser/configurable_spec.rb
+++ b/spec/harmoniser/configurable_spec.rb
@@ -49,17 +49,17 @@ RSpec.describe Harmoniser::Configurable do
     end
   end
 
-  describe ".bunny" do
+  describe ".connection" do
     it "forward to configuration object" do
-      subject.configure { |config| config.bunny = {} }
+      subject.configure { |config| config.connection_opts = { host: "rabbitmq" } }
 
-      expect(subject.bunny).to be_an_instance_of(Bunny::Session)
+      expect(subject.connection).to be_an_instance_of(Harmoniser::Connection)
     end
 
     context "when configuration object is not set" do
       it "raise NoMethodError" do
         expect do
-          subject.bunny
+          subject.connection
         end.to raise_error(NoMethodError, /Please, configure first/)
       end
     end

--- a/spec/harmoniser/connection_spec.rb
+++ b/spec/harmoniser/connection_spec.rb
@@ -1,0 +1,14 @@
+require "harmoniser/connection"
+require "shared_context/configurable"
+
+RSpec.describe Harmoniser::Connection do
+  subject { described_class.new({}) }
+
+  it "responds to create_channel" do
+    expect(subject).to respond_to(:create_channel)
+  end
+
+  it "responds to start" do
+    expect(subject).to respond_to(:start)
+  end
+end

--- a/spec/shared_context/configurable.rb
+++ b/spec/shared_context/configurable.rb
@@ -1,8 +1,10 @@
 RSpec.shared_context "configurable" do
   before(:each) do
     Harmoniser.configure do |config|
-      config.bunny = {host: "rabbitmq"}
+      config.connection_opts = {
+        host: "rabbitmq"
+      }
     end
   end
-  let(:bunny) { Harmoniser.bunny }
+  let(:bunny) { Bunny.new(host: "rabbitmq").start }
 end


### PR DESCRIPTION
Instead of passing a Bunny instance, we prefer to pass a hash of options, that map with the options available to instantiate Bunny::Session class. This will allow us to better control the following:

- Create a unique Bunny::Session shared across Harmoniser module
- Ensure the creation is thread-safe
- Prevent leaking Bunny::Session across the library through the delegation of specific methods like (create_channel or start)