### PR TITLE
feat: [#31] Add Sensible defaults for Bunny connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.5.0] - 2023-12-20
+
+### Added
+- Setup at_exit hook to be executed when Harmoniser exits for an opened RabbitMQ connection
+- Add defaults to Bunny::Session for timeouts and recovery attempts
+- Fix boot up problems for payments application example
+- Perform refactoring of internals such as slimming down Configuration
+
 ## [0.4.0] - 2023-12-07
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    harmoniser (0.4.0)
+    harmoniser (0.5.0)
       bunny (~> 2.22)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ You can also shell into the running container by executing `$ make shell` and fr
 
 - [ ] Issue: Reopen memoized Channel in the context of the class that are included. There are scenarios for which the channel gets closed, for instance Precondition Failed when checking an exchange declaration.
 - [ ] Chore: Introduce simplecov gem for code coverage.
-- [ ] Feature: Add sensible defaults for Session options like heartbeat, timeout, recovery_completed or recovery_attempt_started.
 - [ ] Feature: Add default `on_return` handler as well as permitting the definition of on_return method to be called anytime a published message gets returned.
 - [ ] Feature: Introduce capability of configuring number of threads for queue consuming at the CLI.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,9 @@ services:
       context: examples/payments
     volumes:
       - ./examples/payments:/rails
-    command: ["bundle", "exec", "harmoniser", "--verbose"]
+    environment:
+      - SECRET_KEY_BASE=a_secret_key_base
+    command: ["bundle", "exec", "harmoniser"]
 
   start_dependencies:
     image: dadarek/wait-for-dependencies

--- a/examples/payments/Gemfile
+++ b/examples/payments/Gemfile
@@ -46,4 +46,4 @@ group :development do
 
 end
 
-gem "harmoniser", git: "https://github.com/jollopre/harmoniser", branch: "master"
+gem "harmoniser", git: "https://github.com/jollopre/harmoniser.git"

--- a/examples/payments/Gemfile.lock
+++ b/examples/payments/Gemfile.lock
@@ -1,9 +1,8 @@
 GIT
-  remote: https://github.com/jollopre/harmoniser
-  revision: e8e81f325d14acf16c09f62f5ee901f552166cf8
-  branch: master
+  remote: https://github.com/jollopre/harmoniser.git
+  revision: 149010762c0595386615692ced7452c844ecff8d
   specs:
-    harmoniser (0.3.0)
+    harmoniser (0.4.0)
       bunny (~> 2.22)
 
 GEM
@@ -85,7 +84,7 @@ GEM
       tzinfo (~> 2.0)
     amq-protocol (2.3.2)
     base64 (0.2.0)
-    bigdecimal (3.1.4)
+    bigdecimal (3.1.5)
     bootsnap (1.17.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -96,9 +95,9 @@ GEM
     connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.4)
-    debug (1.8.0)
-      irb (>= 1.5.0)
-      reline (>= 0.3.1)
+    debug (1.9.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
@@ -106,8 +105,8 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    io-console (0.6.0)
-    irb (1.9.1)
+    io-console (0.7.1)
+    irb (1.10.1)
       rdoc
       reline (>= 0.3.8)
     loofah (2.22.0)
@@ -123,7 +122,7 @@ GEM
     minitest (5.20.0)
     msgpack (1.7.2)
     mutex_m (0.2.0)
-    net-imap (0.4.6)
+    net-imap (0.4.8)
       date
       net-protocol
     net-pop (0.1.2)
@@ -132,10 +131,10 @@ GEM
       timeout
     net-smtp (0.4.0)
       net-protocol
-    nio4r (2.6.1)
+    nio4r (2.7.0)
     nokogiri (1.15.5-aarch64-linux)
       racc (~> 1.4)
-    psych (5.1.1.1)
+    psych (5.1.2)
       stringio
     puma (6.4.0)
       nio4r (~> 2.0)
@@ -179,17 +178,17 @@ GEM
       zeitwerk (~> 2.6)
     rake (13.1.0)
     rbtree (0.4.6)
-    rdoc (6.6.0)
+    rdoc (6.6.2)
       psych (>= 4.0.0)
-    reline (0.4.0)
+    reline (0.4.1)
       io-console (~> 0.5)
     ruby2_keywords (0.0.5)
-    set (1.0.3)
+    set (1.0.4)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
     sqlite3 (1.6.9-aarch64-linux)
-    stringio (3.0.9)
+    stringio (3.1.0)
     thor (1.3.0)
     timeout (0.4.1)
     tzinfo (2.0.6)

--- a/lib/harmoniser.rb
+++ b/lib/harmoniser.rb
@@ -1,8 +1,10 @@
 require "harmoniser/version"
 require "harmoniser/configurable"
+require "harmoniser/loggable"
 require "harmoniser/publisher"
 require "harmoniser/subscriber"
 
 module Harmoniser
   extend Configurable
+  extend Loggable
 end

--- a/lib/harmoniser/cli.rb
+++ b/lib/harmoniser/cli.rb
@@ -46,19 +46,17 @@ module Harmoniser
     end
 
     def run
-      launcher = Launcher.new
-      launcher.start
+      Launcher
+        .new(configuration: configuration, logger: logger)
+        .start
 
       while @read_io.wait_readable
         signal = @read_io.gets.strip
         handle_signal(signal)
       end
     rescue Interrupt
-      logger.info("Shutting down!")
-      launcher.stop
       @write_io.close
       @read_io.close
-      logger.info("Bye!")
       exit(0)
     end
 

--- a/lib/harmoniser/configurable.rb
+++ b/lib/harmoniser/configurable.rb
@@ -20,6 +20,6 @@ module Harmoniser
       @configuration ||= Configuration.new
     end
 
-    def_delegators :configuration, :logger, :connection
+    def_delegators :configuration, :connection, :connection?
   end
 end

--- a/lib/harmoniser/connectable.rb
+++ b/lib/harmoniser/connectable.rb
@@ -1,0 +1,49 @@
+require "harmoniser/connection"
+
+module Harmoniser
+  module Connectable
+    MUTEX = Mutex.new
+
+    def connection_opts
+      @connection_opts ||= Connection::DEFAULT_CONNECTION_OPTS.merge({logger: Harmoniser.logger})
+    end
+
+    def connection_opts=(opts)
+      raise TypeError, "opts must be a Hash object" unless opts.is_a?(Hash)
+
+      @connection_opts = connection_opts.merge(opts)
+    end
+
+    def connection
+      MUTEX.synchronize do
+        @connection ||= create_connection
+        @connection.start unless @connection.open? || @connection.recovering_from_network_failure?
+        @connection
+      end
+    end
+
+    def connection?
+      !!defined?(@connection)
+    end
+
+    private
+
+    def create_connection
+      at_exit(&method(:at_exit_handler).to_proc)
+      Connection.new(connection_opts)
+    end
+
+    def at_exit_handler
+      logger = Harmoniser.logger
+
+      logger.info("Shutting down!")
+      if connection? && connection.open?
+        stringified_connection = connection.to_s
+        logger.info("Connection will be closed: connection = `#{stringified_connection}`")
+        connection.close
+        logger.info("Connection closed: connection = `#{stringified_connection}`")
+      end
+      logger.info("Bye!")
+    end
+  end
+end

--- a/lib/harmoniser/connection.rb
+++ b/lib/harmoniser/connection.rb
@@ -4,17 +4,44 @@ require "bunny"
 module Harmoniser
   class Connection
     extend Forwardable
-    def_delegators :@bunny, :close, :create_channel, :open?, :start
+
+    DEFAULT_CONNECTION_OPTS = {
+      connection_name: "harmoniser@#{VERSION}",
+      connection_timout: 5,
+      host: "127.0.0.1",
+      password: "guest",
+      port: 5672,
+      read_timeout: 5,
+      recovery_attempt_started: proc {
+        stringified_connection = Harmoniser.connection.to_s
+        Harmoniser.logger.info("Recovery attempt started: connection = `#{stringified_connection}`")
+      },
+      recovery_completed: proc {
+        stringified_connection = Harmoniser.connection.to_s
+        Harmoniser.logger.info("Recovery completed: connection = `#{stringified_connection}`")
+      },
+      tls_silence_warnings: true,
+      username: "guest",
+      verify_peer: false,
+      vhost: "/",
+      write_timeout: 5
+    }
+
+    def_delegators :@bunny, :close, :create_channel, :open?, :recovering_from_network_failure?, :start
 
     def initialize(opts)
       @bunny = Bunny.new(opts)
     end
 
     def to_s
-      "<#{self.class.name}>: #{user}@#{host}:#{port}, vhost = #{vhost}"
+      "<#{self.class.name}>: #{user}@#{host}:#{port}, connection_name = `#{connection_name}`, vhost = `#{vhost}`"
     end
 
     private
+
+    def connection_name
+      @bunny.connection_name
+    end
 
     def host
       @bunny.transport.host

--- a/lib/harmoniser/launcher.rb
+++ b/lib/harmoniser/launcher.rb
@@ -1,6 +1,6 @@
 module Harmoniser
   class Launcher
-    def initialize(configuration: Harmoniser.configuration, logger: Harmoniser.logger)
+    def initialize(configuration:, logger:)
       @configuration = configuration
       @logger = logger
     end
@@ -8,10 +8,6 @@ module Harmoniser
     def start
       boot_app
       start_subscribers
-    end
-
-    def stop
-      stop_subscribers
     end
 
     private
@@ -31,11 +27,6 @@ module Harmoniser
         klass.harmoniser_subscriber_start
       end
       @logger.info("Subscribers registered to consume messages from queues: klasses = `#{klasses}`")
-    end
-
-    def stop_subscribers
-      @logger.info("Connection will be closed: connection = `#{@configuration.connection}`")
-      @configuration.connection.close
     end
 
     private

--- a/lib/harmoniser/loggable.rb
+++ b/lib/harmoniser/loggable.rb
@@ -1,0 +1,10 @@
+require "logger"
+require "harmoniser/version"
+
+module Harmoniser
+  module Loggable
+    def logger
+      @logger ||= Logger.new($stdout, progname: "harmoniser@#{VERSION}")
+    end
+  end
+end

--- a/lib/harmoniser/version.rb
+++ b/lib/harmoniser/version.rb
@@ -1,3 +1,3 @@
 module Harmoniser
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/harmoniser/configurable_spec.rb
+++ b/spec/harmoniser/configurable_spec.rb
@@ -31,22 +31,24 @@ RSpec.describe Harmoniser::Configurable do
 
       expect(subject.configuration).to be_an_instance_of(Harmoniser::Configuration)
     end
-  end
 
-  describe ".connection" do
-    let(:host) { ENV.fetch("RABBITMQ_HOST") }
-
-    it "forward to configuration object" do
-      subject.configure { |config| config.connection_opts = {host: host} }
-
-      expect(subject.connection).to be_an_instance_of(Harmoniser::Connection)
-    end
-
-    context "when configuration object is not set" do
+    context "when is not configured" do
       it "raise NoMethodError" do
         expect do
-          subject.connection
+          subject.configuration
         end.to raise_error(NoMethodError, /Please, configure first/)
+      end
+    end
+
+    context "delegators" do
+      before { subject.configure {} }
+
+      it "responds to connection" do
+        expect(subject).to respond_to(:connection)
+      end
+
+      it "responds to connection?" do
+        expect(subject).to respond_to(:connection?)
       end
     end
   end
@@ -63,22 +65,6 @@ RSpec.describe Harmoniser::Configurable do
       configuration2 = subject.default_configuration
 
       expect(configuration.object_id).to eq(configuration2.object_id)
-    end
-  end
-
-  describe ".logger" do
-    it "forward to configuration object" do
-      subject.configure {}
-
-      expect(subject.logger).to be_an_instance_of(Logger)
-    end
-
-    context "when configuration object is not set" do
-      it "raise NoMethodError" do
-        expect do
-          subject.logger
-        end.to raise_error(NoMethodError, /Please, configure first/)
-      end
     end
   end
 end

--- a/spec/harmoniser/configuration_spec.rb
+++ b/spec/harmoniser/configuration_spec.rb
@@ -1,96 +1,6 @@
 require "harmoniser/configuration"
 
 RSpec.describe Harmoniser::Configuration do
-  describe "#connection" do
-    subject { described_class.new }
-    let(:host) { ENV.fetch("RABBITMQ_HOST") }
-
-    before do
-      subject.connection_opts = {host: host}
-    end
-
-    it "creates a connection to RabbitMQ using Connection underneath" do
-      expect_any_instance_of(Harmoniser::Connection).to receive(:start)
-
-      subject.connection
-    end
-
-    it "connection creation is thread-safe" do
-      connection_creation = lambda { subject.connection }
-
-      result1 = Thread.new(&connection_creation)
-      result2 = Thread.new(&connection_creation)
-
-      expect(result1.value.object_id).to eq(result2.value.object_id)
-    end
-
-    it "each instance has its own connection" do
-      configuration1 = described_class.new
-      configuration1.connection_opts = {host: host}
-      configuration2 = described_class.new
-      configuration2.connection_opts = {host: host}
-
-      expect(configuration1.connection.object_id).not_to eq(configuration2.connection.object_id)
-    end
-
-    it "a closed connection can be re-opened" do
-      bunny_instance = subject.connection.instance_variable_get(:@bunny)
-      subject.connection.close
-
-      expect(bunny_instance.open?).to eq(false)
-      expect(subject.connection.open?).to eq(true)
-    end
-  end
-
-  describe "#connection_opts=" do
-    let(:version) { Harmoniser::VERSION }
-    subject { described_class.new }
-
-    context "when called with empty opts" do
-      it "uses default connection opts defined" do
-        subject.connection_opts = {}
-
-        expect(subject.connection_opts).to include({
-          connection_name: "harmoniser@#{version}",
-          host: "127.0.0.1",
-          logger: subject.logger,
-          password: "guest",
-          port: 5672,
-          tls_silence_warnings: true,
-          username: "guest",
-          vhost: "/",
-          verify_peer: false
-        })
-      end
-    end
-
-    context "when any argument matching properties of the default connection opts defined is passed" do
-      it "override the properties" do
-        subject.connection_opts = {host: "wadus", password: "secret_password"}
-
-        expect(subject.connection_opts).to include({
-          connection_name: "harmoniser@#{version}",
-          host: "wadus",
-          logger: subject.logger,
-          password: "secret_password",
-          port: 5672,
-          tls_silence_warnings: true,
-          username: "guest",
-          vhost: "/",
-          verify_peer: false
-        })
-      end
-    end
-
-    context "when called without a non Hash object" do
-      it "raises TypeError" do
-        expect do
-          subject.connection_opts = "wadus"
-        end.to raise_error(TypeError, "opts must be a Hash object")
-      end
-    end
-  end
-
   describe "#define_topology" do
     it "yield a topology object" do
       expect do |b|
@@ -163,6 +73,26 @@ RSpec.describe Harmoniser::Configuration do
         result = subject.require
 
         expect(result).to eq(".")
+      end
+    end
+
+    context "connectable" do
+      subject { described_class.new }
+
+      it "responds to connection_opts" do
+        expect(subject).to respond_to(:connection_opts)
+      end
+
+      it "responds to connection_opts=" do
+        expect(subject).to respond_to(:connection_opts=)
+      end
+
+      it "responds to connection" do
+        expect(subject).to respond_to(:connection)
+      end
+
+      it "responds to connection?" do
+        expect(subject).to respond_to(:connection?)
       end
     end
   end

--- a/spec/harmoniser/connectable_spec.rb
+++ b/spec/harmoniser/connectable_spec.rb
@@ -1,0 +1,147 @@
+require "harmoniser/connectable"
+
+RSpec.describe Harmoniser::Connectable do
+  let(:klass) do
+    Class.new do
+      include Harmoniser::Connectable
+    end
+  end
+  let(:version) { Harmoniser::VERSION }
+  subject { klass.new }
+
+  describe "#connection_opts" do
+    it "returns default connection opts" do
+      expect(subject.connection_opts).to include({
+        connection_name: "harmoniser@#{version}",
+        host: "127.0.0.1",
+        logger: be_an_instance_of(Logger),
+        password: "guest",
+        port: 5672,
+        tls_silence_warnings: true,
+        username: "guest",
+        vhost: "/",
+        verify_peer: false
+      })
+    end
+
+    context "when new connection_opts are passed" do
+      it "returns connection opts with overwritten opts" do
+        subject.connection_opts = {connection_name: "wadus"}
+
+        expect(subject.connection_opts).to include({
+          connection_name: "wadus",
+          host: "127.0.0.1",
+          logger: be_an_instance_of(Logger),
+          password: "guest",
+          port: 5672,
+          tls_silence_warnings: true,
+          username: "guest",
+          vhost: "/",
+          verify_peer: false
+        })
+      end
+    end
+  end
+
+  describe "#connection_opts=" do
+    context "when called with empty opts" do
+      it "uses default connection opts defined" do
+        subject.connection_opts = {}
+
+        expect(subject.connection_opts).to include({
+          connection_name: "harmoniser@#{version}",
+          host: "127.0.0.1",
+          logger: be_an_instance_of(Logger),
+          password: "guest",
+          port: 5672,
+          tls_silence_warnings: true,
+          username: "guest",
+          vhost: "/",
+          verify_peer: false
+        })
+      end
+    end
+
+    context "when any argument matching properties of the default connection opts defined is passed" do
+      it "override the properties" do
+        subject.connection_opts = {host: "wadus", password: "secret_password"}
+
+        expect(subject.connection_opts).to include({
+          connection_name: "harmoniser@#{version}",
+          host: "wadus",
+          logger: Harmoniser.logger,
+          password: "secret_password",
+          port: 5672,
+          tls_silence_warnings: true,
+          username: "guest",
+          vhost: "/",
+          verify_peer: false
+        })
+      end
+    end
+
+    context "when called with a non Hash object" do
+      it "raises TypeError" do
+        expect do
+          subject.connection_opts = "wadus"
+        end.to raise_error(TypeError, "opts must be a Hash object")
+      end
+    end
+  end
+
+  describe "#connection" do
+    let(:host) { ENV.fetch("RABBITMQ_HOST") }
+
+    before do
+      subject.connection_opts = {host: host}
+    end
+
+    it "creates a connection to RabbitMQ using Connection underneath" do
+      expect_any_instance_of(Harmoniser::Connection).to receive(:start)
+
+      subject.connection
+    end
+
+    it "connection creation is thread-safe" do
+      connection_creation = lambda { subject.connection }
+
+      result1 = Thread.new(&connection_creation)
+      result2 = Thread.new(&connection_creation)
+
+      expect(result1.value.object_id).to eq(result2.value.object_id)
+    end
+
+    it "a closed connection can be re-opened" do
+      bunny_instance = subject.connection.instance_variable_get(:@bunny)
+      subject.connection.close
+
+      expect(bunny_instance.open?).to eq(false)
+      expect(subject.connection.open?).to eq(true)
+    end
+
+    it "a closed connection due to a network failure CANNOT be re-opened" do
+      bunny_instance = subject.connection.instance_variable_get(:@bunny)
+      subject.connection.close
+      bunny_instance.instance_variable_set(:@recovering_from_network_failure, true)
+
+      expect(subject.connection.open?).to eq(false)
+    end
+  end
+
+  describe ".connection?" do
+    let(:host) { ENV.fetch("RABBITMQ_HOST") }
+    before { subject.connection_opts = {host: host} }
+
+    context "when connection is invoked" do
+      it "returns true" do
+        subject.connection
+
+        expect(subject.connection?).to eq(true)
+      end
+    end
+
+    it "returns false" do
+      expect(subject.connection?).to eq(false)
+    end
+  end
+end

--- a/spec/harmoniser/connection_spec.rb
+++ b/spec/harmoniser/connection_spec.rb
@@ -2,7 +2,7 @@ require "harmoniser/connection"
 require "shared_context/configurable"
 
 RSpec.describe Harmoniser::Connection do
-  subject { described_class.new({}) }
+  subject { described_class.new({connection_name: "wadus"}) }
 
   it "responds to close" do
     expect(subject).to respond_to(:close)
@@ -16,7 +16,17 @@ RSpec.describe Harmoniser::Connection do
     expect(subject).to respond_to(:open?)
   end
 
+  it "respond to recovering_from_network_failure?" do
+    expect(subject).to respond_to(:recovering_from_network_failure?)
+  end
+
   it "responds to start" do
     expect(subject).to respond_to(:start)
+  end
+
+  describe "#to_s" do
+    it "returns a string representation of the connection" do
+      expect(subject.to_s).to eq("<Harmoniser::Connection>: guest@127.0.0.1:5672, connection_name = `wadus`, vhost = `/`")
+    end
   end
 end

--- a/spec/harmoniser/launcher_spec.rb
+++ b/spec/harmoniser/launcher_spec.rb
@@ -42,9 +42,4 @@ RSpec.describe Harmoniser::Launcher do
       subject.start
     end
   end
-
-  describe "#stop" do
-    it "closes connection to AMQP server" do
-    end
-  end
 end

--- a/spec/harmoniser/loggable_spec.rb
+++ b/spec/harmoniser/loggable_spec.rb
@@ -1,0 +1,24 @@
+require "harmoniser/loggable"
+
+RSpec.describe Harmoniser::Loggable do
+  subject do
+    Class.new do
+      extend Harmoniser::Loggable
+    end
+  end
+
+  describe ".logger" do
+    it "returns an instance of Logger" do
+      result = subject.logger
+
+      expect(result).to be_an_instance_of(Logger)
+    end
+
+    it "logger instance is memoized" do
+      result = subject.logger
+      result2 = subject.logger
+
+      expect(result.object_id).to eq(result2.object_id)
+    end
+  end
+end

--- a/spec/harmoniser_spec.rb
+++ b/spec/harmoniser_spec.rb
@@ -14,4 +14,16 @@ RSpec.describe Harmoniser do
       expect(described_class).to respond_to(:configure)
     end
   end
+
+  describe ".default_configuration" do
+    it "respond_to default_configuration" do
+      expect(described_class).to respond_to(:default_configuration)
+    end
+  end
+
+  describe ".logger" do
+    it "respond_to logger" do
+      expect(described_class).to respond_to(:logger)
+    end
+  end
 end


### PR DESCRIPTION
* Move DEFAULT_CONNECTION_OPTS under Connection class
* Refactor Harmoniser.logger to be independent of Harmoniser.configuration
* Setup at_exit to close connection if open
* Refactor connectable methods into its own module included under Configuration instances
* Add defaults to Bunny::Session opts
* Tune when to start Bunny::Session considering whether or not recovery from network failure is ongoing
* Fix boot up problems for payments application example