### PR TITLE
fix: [#41] Exit ruby process only when harmoniser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.8.1] - 2024-04-08
+
+### Fixed
+- Exit ruby process when harmoniser is not the main process. More details at [issue](https://github.com/jollopre/harmoniser/issues/41).
+
 ## [0.8.0] - 2024-03-31
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    harmoniser (0.8.0)
+    harmoniser (0.8.1)
       bunny (~> 2.22)
 
 GEM

--- a/examples/payments/Gemfile.lock
+++ b/examples/payments/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/jollopre/harmoniser.git
-  revision: 149010762c0595386615692ced7452c844ecff8d
+  revision: e0aeac1691e4db1021c19a1c44d5285fdd5bd659
   specs:
-    harmoniser (0.4.0)
+    harmoniser (0.8.0)
       bunny (~> 2.22)
 
 GEM
@@ -183,7 +183,7 @@ GEM
     reline (0.4.1)
       io-console (~> 0.5)
     ruby2_keywords (0.0.5)
-    set (1.0.4)
+    set (1.1.0)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)

--- a/lib/harmoniser.rb
+++ b/lib/harmoniser.rb
@@ -7,4 +7,10 @@ require "harmoniser/subscriber"
 module Harmoniser
   extend Configurable
   extend Loggable
+
+  class << self
+    def server?
+      !!defined?(CLI)
+    end
+  end
 end

--- a/lib/harmoniser/connection.rb
+++ b/lib/harmoniser/connection.rb
@@ -83,7 +83,7 @@ module Harmoniser
       yield if block_given?
     rescue SignalException => e
       Harmoniser.logger.info("Signal received: signal = `#{Signal.signame(e.signo)}`")
-      exit(0)
+      Harmoniser.server? ? exit(0) : raise
     end
   end
 end

--- a/lib/harmoniser/version.rb
+++ b/lib/harmoniser/version.rb
@@ -1,3 +1,3 @@
 module Harmoniser
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end

--- a/spec/harmoniser_spec.rb
+++ b/spec/harmoniser_spec.rb
@@ -26,4 +26,20 @@ RSpec.describe Harmoniser do
       expect(described_class).to respond_to(:logger)
     end
   end
+
+  describe ".server?" do
+    it "returns false" do
+      expect(described_class.server?).to eq(false)
+    end
+
+    context "when `CLI` is loaded" do
+      before do
+        load "harmoniser/cli.rb"
+      end
+
+      it "returns true" do
+        expect(described_class.server?).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Update example app to latest gem version
* Exit ruby process only when harmoniser is the main process