### PR TITLE
feat: [#52] Selective retry for connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.12.0] - 2024-12-22
+
+### Changed
+- Perform retries connecting to RabbitMQ only if Harmoniser runs as the main process
+- Change from IO.pipe to Thread::Queue so that an OS signal is exchanged through a queue safely.
+
 ## [0.11.0] - 2024-10-09
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    harmoniser (0.11.0)
+    harmoniser (0.12.0)
       bunny (~> 2.23)
 
 GEM

--- a/lib/harmoniser/version.rb
+++ b/lib/harmoniser/version.rb
@@ -1,3 +1,3 @@
 module Harmoniser
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end


### PR DESCRIPTION
* Remove SignalException from Connection using Thread::Queue to communicate main process with thread dedicated to launch harmoniser
* Refactor some bits for cli for better readability
* Retry connecting only when Harmoniser is the main process, i.e. Harmoniser.server? is true