### PR TITLE
feat: [#55] Add Error handlers functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.13.0] - 2025-05-19
+
+### Added
+- Introduce Harmoniser.configuration#on_error callback to handle errors that occur while running the application, (e.g. when a subscriber raises an error, or when a connection cannot be established to RabbitMQ). This method permits appending as many handlers as needed. Usage:
+
+```ruby
+Harmoniser.configuration do |config|
+  config.on_error do |error, ctx|
+    # error is the exception, i.e. StandardError class raised by the application whereas ctx is the context of the error passed as Hash. The ctx hash contains at least the key `description` which is a string describing the error.
+
+    puts "An error occurred: exception = `#{error.detailed_message}`; description = `#{ctx[:description]}`"
+  end
+end
+```
+
+### Changed
+- Update Bunny to the latest version, i.e., 2.24
+- Delegate into Bunny::Channel to cancel consumers and close channel through
+Channel#cancel_consumers_before_closing!
+- Change severity level from error to warning for errors occurring at channel level
+
+
 ## [0.12.0] - 2024-12-22
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ruby:3.3.4-alpine3.20 as base
+FROM ruby:3.3.4-alpine3.20 AS base
 ENV APP /opt
 WORKDIR $APP
 COPY Gemfile Gemfile.lock harmoniser.gemspec Rakefile $APP/
 
-FROM base as test
+FROM base AS test
 RUN apk --update add --virtual build_deps build-base
 COPY lib $APP/lib/ 
 COPY spec $APP/spec/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 PATH
   remote: .
   specs:
-    harmoniser (0.12.0)
-      bunny (~> 2.23)
+    harmoniser (0.13.0)
+      bunny (~> 2.24)
 
 GEM
   remote: https://rubygems.org/
   specs:
     amq-protocol (2.3.2)
     ast (2.4.2)
-    bunny (2.23.0)
-      amq-protocol (~> 2.3, >= 2.3.1)
+    bunny (2.24.0)
+      amq-protocol (~> 2.3)
       sorted_set (~> 1, >= 1.0.2)
     diff-lcs (1.5.1)
     json (2.7.2)

--- a/harmoniser.gemspec
+++ b/harmoniser.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.executables = ["harmoniser"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "bunny", "~> 2.23"
+  spec.add_runtime_dependency "bunny", "~> 2.24"
 end

--- a/lib/harmoniser/error_handler.rb
+++ b/lib/harmoniser/error_handler.rb
@@ -1,0 +1,51 @@
+module Harmoniser
+  class ErrorHandler
+    TIMEOUT = 25
+    DEFAULT_ERROR_HANDLER = ->(exception, ctx) do
+      Harmoniser.logger.error("Error handler called: exception = `#{exception.detailed_message}`, context = `#{ctx}`")
+    end
+
+    class << self
+      def default
+        @default ||= new([DEFAULT_ERROR_HANDLER])
+      end
+    end
+
+    def initialize(handlers = [])
+      @handlers = handlers
+    end
+
+    def on_error(handler = nil, &block)
+      h = handler || block
+      raise ArgumentError, "Please, provide a handler or a block" if h.nil?
+      raise TypeError, "Handler must respond to call" unless h.respond_to?(:call)
+
+      @handlers << h
+      self
+    end
+
+    def handle_error(exception, ctx = {})
+      coordinator = Thread::Queue.new
+
+      Thread.new do
+        handlers
+          .each { |handler| trigger_handler(handler, exception, ctx) }
+          .tap { coordinator.push(true) }
+      end.tap do |thread|
+        thread.report_on_exception = true
+      end
+
+      !!coordinator.pop(timeout: TIMEOUT)
+    end
+
+    private
+
+    attr_reader :handlers
+
+    def trigger_handler(handler, exception, ctx)
+      handler.call(exception, ctx)
+    rescue => e
+      warn "An error occurred while handling a previous error: #{e.detailed_message}"
+    end
+  end
+end

--- a/lib/harmoniser/launcher/base.rb
+++ b/lib/harmoniser/launcher/base.rb
@@ -61,15 +61,13 @@ module Harmoniser
       def maybe_close_subscriber
         return unless Subscriber.connection?
 
-        maybe_cancel_subscribers
+        report_subscribers_to_cancel
         report_work_pool
         Subscriber.connection.close
       end
 
-      def maybe_cancel_subscribers
+      def report_subscribers_to_cancel
         @logger.info("Subscribers will be cancelled from queues: klasses = `#{@subscribers}`")
-        @subscribers.each(&:harmoniser_subscriber_stop)
-        @logger.info("Subscribers cancelled: klasses = `#{@subscribers}`")
       end
 
       def report_work_pool

--- a/lib/harmoniser/options.rb
+++ b/lib/harmoniser/options.rb
@@ -1,5 +1,21 @@
 module Harmoniser
-  Options = Data.define(:concurrency, :environment, :require, :verbose, :timeout) do
+  class Options < Data.define(:concurrency, :environment, :require, :verbose, :timeout)
+    DEFAULT = {
+      concurrency: -> { Float::INFINITY },
+      environment: -> { ENV.fetch("RAILS_ENV", ENV.fetch("RACK_ENV", "production")) },
+      require: -> { "." },
+      timeout: -> { 25 },
+      verbose: -> { false }
+    }.freeze
+
+    def initialize(**kwargs)
+      options = DEFAULT
+        .map { |k, v| [k, v.call] }
+        .to_h
+        .merge(kwargs)
+      super(**options)
+    end
+
     def production?
       environment == "production"
     end

--- a/lib/harmoniser/version.rb
+++ b/lib/harmoniser/version.rb
@@ -1,3 +1,3 @@
 module Harmoniser
-  VERSION = "0.12.0"
+  VERSION = "0.13.0"
 end

--- a/spec/harmoniser/configuration_spec.rb
+++ b/spec/harmoniser/configuration_spec.rb
@@ -173,6 +173,18 @@ RSpec.describe Harmoniser::Configuration do
         expect(subject).to respond_to(:connection_opts=)
       end
     end
+
+    context "error_handler" do
+      subject { described_class.new }
+
+      it "responds to handle_error" do
+        expect(subject).to respond_to(:handle_error)
+      end
+
+      it "responds to on_error" do
+        expect(subject).to respond_to(:on_error)
+      end
+    end
   end
 
   describe "#logger" do

--- a/spec/harmoniser/connectable_spec.rb
+++ b/spec/harmoniser/connectable_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Harmoniser::Connectable do
     end
 
     it "connection creation is thread-safe" do
-      connection_creation = lambda { klass.connection }
+      connection_creation = -> { klass.connection }
 
       result1 = Thread.new(&connection_creation)
       result2 = Thread.new(&connection_creation)
@@ -81,7 +81,7 @@ RSpec.describe Harmoniser::Connectable do
 
         expect do
           on_error.call(subject, method)
-        end.to output(/ERROR -- .*Default on_error handler executed for channel: amq_method = `.*`, exchanges = `\[\]`, queues = `\[\]`, reply_code = `406`, reply_text = `unknown delivery tag`/).to_stdout_from_any_process
+        end.to output(/WARN -- .*Default on_error handler executed for channel: amq_method = `.*`, exchanges = `\[\]`, queues = `\[\]`, reply_code = `406`, reply_text = `unknown delivery tag`/).to_stdout_from_any_process
       end
 
       context "for any other amq_method is received" do
@@ -91,7 +91,7 @@ RSpec.describe Harmoniser::Connectable do
 
           expect do
             on_error.call(subject, method)
-          end.to output(/ERROR -- .*Default on_error handler executed for channel: amq_method = `.*`, exchanges = `\[\]`, queues = `\[\]`/).to_stdout_from_any_process
+          end.to output(/WARN -- .*Default on_error handler executed for channel: amq_method = `.*`, exchanges = `\[\]`, queues = `\[\]`/).to_stdout_from_any_process
         end
       end
 
@@ -138,7 +138,7 @@ RSpec.describe Harmoniser::Connectable do
 
         expect do
           on_uncaught_exception.call(StandardError.new("wadus"), consumer)
-        end.to output(/ERROR -- .*Default on_uncaught_exception handler executed for channel/).to_stdout_from_any_process
+        end.to output(/ERROR -- .*Error handler called: exception = `wadus \(StandardError\)`/).to_stdout_from_any_process
       end
     end
   end

--- a/spec/harmoniser/connection_spec.rb
+++ b/spec/harmoniser/connection_spec.rb
@@ -104,11 +104,10 @@ RSpec.describe Harmoniser::Connection do
 
       it "log with error severity is output" do
         allow(bunny).to receive(:close).and_raise("Error")
-        allow(logger).to receive(:error)
 
-        subject.close
-
-        expect(logger).to have_received(:error).with(/Connection#close failed: error_class = `RuntimeError`, error_message = `Error`/)
+        expect do
+          subject.close
+        end.to output(/.*ERROR -- .*Connection close failed"/).to_stdout_from_any_process
       end
     end
   end
@@ -119,7 +118,6 @@ RSpec.describe Harmoniser::Connection do
     context "when `server?`" do
       before do
         allow(Harmoniser).to receive(:server?).and_return(true)
-        allow(logger).to receive(:error)
         allow(subject).to receive(:sleep)
         allow(bunny).to receive(:start) do
           @retries ||= 0
@@ -131,9 +129,9 @@ RSpec.describe Harmoniser::Connection do
       end
 
       it "retries establishing connection until succeeding" do
-        subject.start
-
-        expect(logger).to have_received(:error).with(/Connection attempt failed: retries = `.*`, error_class = `RuntimeError`, error_message = `Error`/).twice
+        expect do
+          subject.start
+        end.to output(/.*ERROR -- .*"Connection attempt failed".*ERROR -- .*"Connection attempt failed"/m).to_stdout_from_any_process
       end
     end
 

--- a/spec/harmoniser/error_handler_spec.rb
+++ b/spec/harmoniser/error_handler_spec.rb
@@ -1,0 +1,96 @@
+require "harmoniser/error_handler"
+
+RSpec.describe Harmoniser::ErrorHandler do
+  describe "#on_error" do
+    subject { described_class.new }
+
+    it "appends the error handler to the list of error handlers" do
+      handler = proc { |error, ctx| }
+
+      subject.on_error(handler)
+
+      expect(subject.instance_variable_get(:@handlers)).to include(handler)
+    end
+
+    it "appends a block to the list of error handlers" do
+      block = proc { |error, ctx| }
+
+      subject.on_error(&block)
+
+      expect(subject.instance_variable_get(:@handlers)).to include(block)
+    end
+
+    context "when no handler or block is passed" do
+      it "raises ArgumentError" do
+        expect do
+          subject.on_error
+        end.to raise_error(ArgumentError, "Please, provide a handler or a block")
+      end
+    end
+
+    context "when handler is passed bues not respond to call" do
+      it "raises TypeError" do
+        expect do
+          subject.on_error(Object.new)
+        end.to raise_error(TypeError, "Handler must respond to call")
+      end
+    end
+  end
+
+  describe "#handle_error" do
+    subject { described_class.new }
+    let(:exception) { StandardError.new("An error occurred") }
+    let(:ctx) { {description: "Something happened"} }
+    let(:handler1) { proc { |e, c| puts "Handler 1: #{e.detailed_message}, Context: #{c}" } }
+    let(:handler2) { proc { |e, c| puts "Handler 2: #{e.detailed_message}, Context: #{c}" } }
+
+    before do
+      subject.on_error(handler1)
+      subject.on_error(handler2)
+    end
+
+    it "executes every error_handler defined" do
+      expect(handler1).to receive(:call).with(exception, ctx).and_call_original
+      expect(handler2).to receive(:call).with(exception, ctx).and_call_original
+
+      subject.handle_error(exception, ctx)
+    end
+
+    context "when any error handler defined raises an error" do
+      let(:handler1) { proc { |e, c| raise "boom!" } }
+
+      it "ignores it and continues executing the rest of the handlers" do
+        expect(handler1).to receive(:call).with(exception, ctx).and_call_original
+        expect(handler2).to receive(:call).with(exception, ctx).and_call_original
+
+        subject.handle_error(exception, ctx)
+      end
+
+      it "reports the error from the handler" do
+        expect do
+          subject.handle_error(exception, ctx)
+        end.to output(/An error occurred while handling a previous error/).to_stderr_from_any_process
+      end
+    end
+
+    context "when timeout is met while executing the handlers" do
+      let(:call_counter) { [] }
+      let(:handler1) {
+        proc { |e, c|
+          call_counter.push(true)
+          sleep(1)
+        }
+      }
+      let(:handler2) { proc { |e, c| call_counter.push(true) } }
+      before do
+        stub_const("Harmoniser::ErrorHandler::TIMEOUT", 0.1)
+      end
+
+      it "interrupts the execution" do
+        subject.handle_error(exception, ctx)
+
+        expect(call_counter.size).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/harmoniser/launcher_spec.rb
+++ b/spec/harmoniser/launcher_spec.rb
@@ -113,13 +113,12 @@ RSpec.describe Harmoniser::Launcher do
     end
 
     describe "#stop" do
-      it "cancels subscribers, informs about work pool" do
+      it "reports subscribers to be cancelled and informs about work pool" do
         configuration.options_with(require: filepath, concurrency: Float::INFINITY)
         subject.start
 
         expect(logger).to receive(:info).with("Shutting down!")
         expect(logger).to receive(:info).with(/Subscribers will be cancelled from queues: klasses = /)
-        expect(logger).to receive(:info).with(/Subscribers cancelled: klasses = /)
         expect(logger).to receive(:info).with(/Stats about the work pool: work_pool_reporter = .*\. Note: A backlog greater than zero means messages could be lost for subscribers configured with no_ack, i.e. automatic ack/)
         expect(logger).to receive(:info).with("Bye!")
 
@@ -166,14 +165,13 @@ RSpec.describe Harmoniser::Launcher do
     end
 
     describe "#stop" do
-      it "cancels subscribers, informs about work pool" do
+      it "reports subscribers to be cancelled and informs about work pool" do
         configuration.options_with(require: filepath, concurrency: concurrency)
 
         subject.start
 
         expect(logger).to receive(:info).with("Shutting down!")
         expect(logger).to receive(:info).with(/Subscribers will be cancelled from queues: klasses = /)
-        expect(logger).to receive(:info).with(/Subscribers cancelled: klasses = /)
         expect(logger).to receive(:info).with(/Stats about the work pool: work_pool_reporter = .*\. Note: A backlog greater than zero means messages could be lost for subscribers configured with no_ack, i.e. automatic ack/)
         expect(logger).to receive(:info).with("Bye!")
 

--- a/spec/harmoniser/options_spec.rb
+++ b/spec/harmoniser/options_spec.rb
@@ -1,15 +1,22 @@
 require "harmoniser/options"
 
 RSpec.describe Harmoniser::Options do
-  let(:concurrency) { Float::INFINITY }
-  let(:environment) { "production" }
-  let(:require) { "." }
-  let(:timeout) { 25 }
-  let(:verbose) { false }
+  describe ".new" do
+    it "initializes with default values" do
+      result = described_class.new
 
-  subject { described_class.new(concurrency:, environment:, require:, timeout:, verbose:) }
+      expect(result.concurrency).to eq(Float::INFINITY)
+      expect(result.environment).to eq("production")
+      expect(result.require).to eq(".")
+      expect(result.timeout).to eq(25)
+      expect(result.verbose).to eq(false)
+    end
+  end
 
   describe "#unbounded_concurrency?" do
+    let(:concurrency) { Float::INFINITY }
+    subject { described_class.new(concurrency:) }
+
     it "returns true" do
       expect(subject.unbounded_concurrency?).to eq(true)
     end


### PR DESCRIPTION
* Centralise defaults for Harmoniser::Options
* Bump bunny to its latest
* Use cancel_consumers_before_closing! for channels
* Remove warnings from Dockerfile
* Change severity of default channel errors log to WARN
* Introduce Harmoniser.configuration#on_error
* Introduce Harmoniser.configuration#handle_error
* Replace usages of logger with error severity with handle_error