### PR TITLE
feat: [#59] Gracefully close channels before connection shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.15.0] - 2026-03-03
+
+### Changed
+- Close all channels tracked by `Harmoniser::Connection` before closing the connection. This ensures consumers are cancelled and channels are closed while the connection is still open, preventing `Bunny::ConnectionClosedError` that could occur when a consumer acknowledges a message concurrently during shutdown
+- Introduce `Harmoniser::Channel#close` and `Harmoniser::Channel#open?` to expose channel lifecycle as part of the public interface
+- Inject logger into `Harmoniser::Channel` for consistent logger usage across the codebase
+
 ## [0.14.0] - 2025-11-25
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    harmoniser (0.14.0)
+    harmoniser (0.15.0)
       bunny (~> 2.24)
 
 GEM

--- a/lib/harmoniser/channel.rb
+++ b/lib/harmoniser/channel.rb
@@ -6,14 +6,23 @@ module Harmoniser
 
     def_delegators :@bunny_channel,
       :exchange,
+      :open?,
       :queue,
       :queue_bind
 
     attr_reader :bunny_channel
 
-    def initialize(bunny_channel)
+    def initialize(bunny_channel, logger: Harmoniser.logger)
       @bunny_channel = bunny_channel
+      @logger = logger
       after_initialize
+    end
+
+    def close
+      @bunny_channel.close
+    rescue => e
+      @logger.warn("Failed to close channel: exception = `#{e.detailed_message}`")
+      false
     end
 
     private
@@ -41,7 +50,7 @@ module Harmoniser
       end
 
       stringified_attributes = attributes.map { |k, v| "#{k} = `#{v}`" }.join(", ")
-      Harmoniser.logger.warn("Default on_error handler executed for channel: #{stringified_attributes}")
+      @logger.warn("Default on_error handler executed for channel: #{stringified_attributes}")
       maybe_kill_process(amq_method)
     end
 

--- a/lib/harmoniser/connectable.rb
+++ b/lib/harmoniser/connectable.rb
@@ -22,6 +22,7 @@ module Harmoniser
         connection
           .create_channel(nil, consumer_pool_size, false, consumer_pool_shutdown_timeout)
           .yield_self { |bunny_channel| Channel.new(bunny_channel) }
+          .tap { |channel| connection.register_channel(channel) }
       end
     end
 

--- a/lib/harmoniser/connection.rb
+++ b/lib/harmoniser/connection.rb
@@ -25,9 +25,14 @@ module Harmoniser
     def initialize(opts, error_handler: ErrorHandler.default, logger: Harmoniser.logger)
       @error_handler = error_handler
       @logger = logger
+      @channels = []
       @bunny = Bunny.new(maybe_dynamic_opts(opts)).tap do |bunny|
         attach_callbacks(bunny)
       end
+    end
+
+    def register_channel(channel)
+      @channels << channel
     end
 
     def to_s
@@ -54,6 +59,7 @@ module Harmoniser
 
     def close
       @logger.info("Connection will be closed: connection = `#{self}`")
+      close_channels
       @bunny.close.tap do
         @logger.info("Connection closed: connection = `#{self}`")
       end
@@ -63,6 +69,10 @@ module Harmoniser
     end
 
     private
+
+    def close_channels
+      @channels.each { |channel| channel.close if channel.open? }
+    end
 
     def attach_callbacks(bunny)
       bunny.on_blocked do |blocked|

--- a/lib/harmoniser/version.rb
+++ b/lib/harmoniser/version.rb
@@ -1,3 +1,3 @@
 module Harmoniser
-  VERSION = "0.14.0"
+  VERSION = "0.15.0"
 end

--- a/spec/harmoniser/channel_spec.rb
+++ b/spec/harmoniser/channel_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "harmoniser/channel"
+require "shared_context/configurable"
+
+RSpec.describe Harmoniser::Channel do
+  include_context "configurable"
+
+  subject { Harmoniser::Subscriber.create_channel }
+
+  describe "#open?" do
+    it "returns true on a freshly created channel" do
+      expect(subject.open?).to eq(true)
+    end
+
+    it "returns false after close" do
+      subject.close
+
+      expect(subject.open?).to eq(false)
+    end
+  end
+
+  describe "#close" do
+    it "closes the underlying bunny channel" do
+      subject.close
+
+      expect(subject.bunny_channel.open?).to eq(false)
+    end
+
+    context "when the channel is already closed" do
+      it "returns false and warns about the failure" do
+        subject.bunny_channel.close
+
+        expect do
+          result = subject.close
+          expect(result).to eq(false)
+        end.to output(/Failed to close channel: exception = `/).to_stdout_from_any_process
+      end
+    end
+
+    context "when a custom logger is injected" do
+      let(:custom_logger) { Logger.new(IO::NULL) }
+      subject(:channel_with_custom_logger) do
+        described_class.new(Harmoniser::Subscriber.create_channel.bunny_channel, logger: custom_logger)
+      end
+
+      it "uses the injected logger to warn about the failure" do
+        channel_with_custom_logger.bunny_channel.close
+        expect(custom_logger).to receive(:warn).with(/Failed to close channel: exception = `/)
+
+        channel_with_custom_logger.close
+      end
+    end
+  end
+
+  describe "on_error_callback" do
+    context "when a custom logger is injected" do
+      let(:custom_logger) { Logger.new(IO::NULL) }
+      subject(:channel_with_custom_logger) do
+        described_class.new(Harmoniser::Subscriber.create_channel.bunny_channel, logger: custom_logger)
+      end
+
+      it "uses the injected logger to warn about the channel error" do
+        amq_method = AMQ::Protocol::Channel::Close.new(406, "unknown delivery tag", nil, nil)
+        on_error = channel_with_custom_logger.bunny_channel.instance_variable_get(:@on_error)
+        expect(custom_logger).to receive(:warn).with(/Default on_error handler executed for channel:/)
+
+        on_error.call(channel_with_custom_logger.bunny_channel, amq_method)
+      end
+    end
+  end
+end

--- a/spec/harmoniser/connectable_spec.rb
+++ b/spec/harmoniser/connectable_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe Harmoniser::Connectable do
       end
     end
 
+    it "registers the created channel on the connection" do
+      channel = klass.create_channel
+
+      expect(klass.connection.instance_variable_get(:@channels)).to include(channel)
+    end
+
     context "when an error occurs at channel level" do
       subject(:channel) { klass.create_channel.bunny_channel }
 

--- a/spec/harmoniser/connection_spec.rb
+++ b/spec/harmoniser/connection_spec.rb
@@ -75,6 +75,22 @@ RSpec.describe Harmoniser::Connection do
     end
   end
 
+  describe "#register_channel" do
+    include_context "configurable"
+
+    subject { described_class.new({connection_name: "wadus", host: host}, logger: logger).tap(&:start) }
+
+    after { subject.close }
+
+    it "registers the channel so it is tracked by the connection" do
+      channel = Harmoniser::Channel.new(subject.create_channel)
+
+      subject.register_channel(channel)
+
+      expect(subject.instance_variable_get(:@channels)).to include(channel)
+    end
+  end
+
   describe "#close" do
     let(:bunny) { subject.instance_variable_get(:@bunny) }
 
@@ -91,6 +107,34 @@ RSpec.describe Harmoniser::Connection do
       expect(logger).to receive(:info).with(/Connection closed: connection =/)
 
       subject.close
+    end
+
+    context "when a channel is registered" do
+      include_context "configurable"
+
+      subject { described_class.new({connection_name: "wadus", host: host}, logger: logger).tap(&:start) }
+
+      let(:channel) do
+        Harmoniser::Channel.new(subject.create_channel).tap do |ch|
+          subject.register_channel(ch)
+        end
+      end
+
+      it "closes the channel before closing the connection" do
+        channel
+
+        subject.close
+
+        expect(channel.open?).to eq(false)
+      end
+
+      context "when the channel is already closed" do
+        it "does not raise" do
+          channel.bunny_channel.close
+
+          expect { subject.close }.not_to raise_error
+        end
+      end
     end
 
     context "when closing connection fails" do


### PR DESCRIPTION
Implement channel lifecycle tracking and ensure all channels are closed before the Bunny connection closes. This prevents Bunny::ConnectionClosedError that can occur when a consumer acks a message concurrently while the connection status is set to :closing during shutdown.

Changes:
- Add logger injection to Channel#initialize with Harmoniser.logger default
- Add open? delegator to Channel for state queries
- Add explicit Channel#close method with error handling and logging
- Track channels in Connection with @channels array
- Add Connection#register_channel(channel) to register new channels
- Add Connection#close_channels private method to close all tracked channels before closing the Bunny connection
- Update Connectable#create_channel to register channels on connection
- Update Channel#on_error_callback to use @logger instance variable